### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://ccllppuu.visualstudio.com/87275cff-ed9d-436c-bfee-6596a9fe076d/955caff2-71e7-4e9f-8610-06e59ccc9db0/_apis/work/boardbadge/d3c14087-f482-48fd-94c1-7c032be1ab7a)](https://ccllppuu.visualstudio.com/87275cff-ed9d-436c-bfee-6596a9fe076d/_boards/board/t/955caff2-71e7-4e9f-8610-06e59ccc9db0/Microsoft.RequirementCategory)
 ♛
 ⇜Enjoying Github⇝
 ✭ 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#241](https://ccllppuu.visualstudio.com/87275cff-ed9d-436c-bfee-6596a9fe076d/_workitems/edit/241). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.